### PR TITLE
Support debian sid and testing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ elif [[ "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
-    if [[ ${os_version} -lt 11 ]]; then
+    if [[ ${os_version} -lt 11 ]] && [[ $(</etc/debian_release) != */sid ]]; then
         echo -e "${red} Please use Debian 11 or higher ${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "almalinux" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ elif [[ "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
-    if [[ ${os_version} -lt 11 ]] && [[ $(</etc/debian_release) != */sid ]]; then
+    if [[ ${os_version} -lt 11 ]] && [[ $(</etc/debian_version) != */sid ]]; then
         echo -e "${red} Please use Debian 11 or higher ${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "almalinux" ]]; then


### PR DESCRIPTION
A lot of people run debian testing to get not-totally-old software. Unfortunately, there is no LSB $VERSION_ID for these systems, so some extra detection is required.